### PR TITLE
Use VINCA_reader as SSID

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -110,7 +110,7 @@ void setup() {
   attachInterrupt(digitalPinToInterrupt(SCLCK), clock_isr, FALLING);
 
   String deviceName = "VINCA_reader";  // Soft AP and device name for OTA.
-  IOT.initIOT(deviceName, "", "ThisPa55word!", deviceName);
+  IOT.initIOT(deviceName, "password", "ThisPa55word!", deviceName);
 
   IOT.server.on("/", handle_index);
   IOT.server.on("/favicon.png", handle_favicon);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -108,8 +108,10 @@ void setup() {
   pinMode(LED, OUTPUT);
 
   attachInterrupt(digitalPinToInterrupt(SCLCK), clock_isr, FALLING);
-  
-  IOT.initIOT("ThisPa55word!","VINCA_reader");
+
+  String deviceName = "VINCA_reader";  // Soft AP and device name for OTA.
+  IOT.initIOT(deviceName, "", "ThisPa55word!", deviceName);
+
   IOT.server.on("/", handle_index);
   IOT.server.on("/favicon.png", handle_favicon);
   IOT.server.on("/csv.png", handle_csvpng);


### PR DESCRIPTION
Use the device name (VINCA_reader) for OTA also as the Soft AP SSID. This way it's easier to figure out the AP when connecting to the cable.

Previously the AP SSID was "ESP_IOT" (default value). The Soft AP still has "password" as password.